### PR TITLE
changed rails dependency to 5.0

### DIFF
--- a/rworkflow.gemspec
+++ b/rworkflow.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'sidekiq', '~> 4'
-  s.add_dependency 'rails', '~> 4.2'
+  s.add_dependency 'rails', '~> 5.0'
   s.add_dependency 'redis_rds', '~> 0.1'
-
   s.add_development_dependency 'sqlite3', '~> 1.3'
 end


### PR DESCRIPTION
Redmine issue: https://redmine.offerista.com/issues/61248
In order to update Rails version to 5.2 in project CimRails.
Tests are passing locally and on travis. 
Anyways this gem should be removed but I needed to update this so i can continue on CimRails